### PR TITLE
BEM helper: allow to skip element and modifiers arguments

### DIFF
--- a/addon/helpers/bem.js
+++ b/addon/helpers/bem.js
@@ -11,10 +11,10 @@ export function bem(params, additionalModifiers) {
 
   base = params[0];
   if (isArray(params[1])) {
-    modifiers = params[1];
+    modifiers = params[1] || A();
   } else {
     element = params[1];
-    modifiers = params[2];
+    modifiers = params[2] || A();
   }
 
   let baseClass = A([base, element]).compact().join('__');

--- a/addon/helpers/bem.js
+++ b/addon/helpers/bem.js
@@ -1,17 +1,24 @@
 import Ember from 'ember';
 import config from 'ember-get-config';
-import {
-  get
-} from '@ember/object';
+import { get } from '@ember/object';
+import { isArray, A } from '@ember/array';
+
 export function bem(params, additionalModifiers) {
 
   // return params;
-  let globalBase = get(config, 'bem-sauce.globalBaseClass'),
-    base = params[0],
-    element = params[1],
-    modifiers = params[2],
-    baseClass = `${base}__${element}`,
-    classNames = Ember.A();
+  let globalBase = get(config, 'bem-sauce.globalBaseClass');
+  let base, element, modifiers;
+
+  base = params[0];
+  if (isArray(params[1])) {
+    modifiers = params[1];
+  } else {
+    element = params[1];
+    modifiers = params[2];
+  }
+
+  let baseClass = A([base, element]).compact().join('__');
+  let classNames = A();
 
   if (globalBase) {
     classNames.pushObject(globalBase);

--- a/tests/integration/helpers/bem-test.js
+++ b/tests/integration/helpers/bem-test.js
@@ -68,7 +68,7 @@ test('test helper returns correct modifier classes with additional custom modifi
   assert.equal(this.$().text().trim(), 'component__element component__element--active component__element--primary component__element--foo');
 });
 
-test('test helper returns correct modifier classes without even if no element is provided', function(assert) {
+test('test helper returns correct modifier classes even if no element is provided', function(assert) {
 
   this.set('b', 'component');
   this.set('m', ['active', 'primary']);
@@ -78,6 +78,22 @@ test('test helper returns correct modifier classes without even if no element is
   this.render(hbs `{{bem b m boop=boop foo=bar}}`);
 
   assert.equal(this.$().text().trim(), 'component component--active component--primary component--foo');
+});
+
+test('test helper returns correct modifier classes even if no modifiers are provided', function(assert) {
+
+  this.set('b', 'component');
+  this.set('m', ['active', 'primary']);
+  this.set('boop', false);
+  this.set('bar', true);
+
+  this.render(hbs `{{bem b boop=boop foo=bar}}`);
+
+  assert.equal(this.$().text().trim(), 'component component--foo');
+
+  this.render(hbs `{{bem b 'element' boop=boop foo=bar}}`);
+
+  assert.equal(this.$().text().trim(), 'component__element component__element--foo');
 });
 
 test('test dummy component', function(assert) {

--- a/tests/integration/helpers/bem-test.js
+++ b/tests/integration/helpers/bem-test.js
@@ -68,6 +68,18 @@ test('test helper returns correct modifier classes with additional custom modifi
   assert.equal(this.$().text().trim(), 'component__element component__element--active component__element--primary component__element--foo');
 });
 
+test('test helper returns correct modifier classes without even if no element is provided', function(assert) {
+
+  this.set('b', 'component');
+  this.set('m', ['active', 'primary']);
+  this.set('boop', false);
+  this.set('bar', true);
+
+  this.render(hbs `{{bem b m boop=boop foo=bar}}`);
+
+  assert.equal(this.$().text().trim(), 'component component--active component--primary component--foo');
+});
+
 test('test dummy component', function(assert) {
   this.set('disabled', false);
 


### PR DESCRIPTION
I'm moving towards tagless Glimmer components. It would be nice to generate BEM classes for the root component tag (block) using the `bem` helper.

What I propose is to make element and modifiers arguments optional:

```handlebars
<div class={{bem "post" private=@model.isPrivate}}>
    <h1 class={{bem "post" "header" big=true}}>{{@model.title}}</h1>
</div>
```

Which renders to:

```html
<div class="post post--private">
    <h1 class="post__header post__header--big">{{@model.title}}</h1>
</div>
```