### PR TITLE
Ember-get-config should be in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.3.0"
+    "ember-cli-babel": "^6.3.0",
+    "ember-get-config": "^0.2.4"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
@@ -36,7 +37,6 @@
     "ember-copy": "^1.0.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
-    "ember-get-config": "^0.2.4",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.14.1",


### PR DESCRIPTION
Currently `ember-get-config` is listed under `devDependencies`. This doesn't work in my app, I got `Could not find module ember-get-config imported from ember-bem-sauce/helpers/bem` error in production. In development it works, cause I'm using `ember-cli-mirage` which includes `ember-get-config`.

TLDR: I moved `ember-dev-config` to `dependencies` and now it is available in the consuming app.